### PR TITLE
Update RemoveData

### DIFF
--- a/lib/utils/services/hive/main_box.dart
+++ b/lib/utils/services/hive/main_box.dart
@@ -43,7 +43,7 @@ mixin class MainBoxMixin {
 
   Future<void> logoutBox() async {
     /// Clear the box
-    removeData(MainBoxKeys.isLogin);
-    removeData(MainBoxKeys.authToken);
+    await removeData(MainBoxKeys.isLogin);
+    await removeData(MainBoxKeys.authToken);
   }
 }


### PR DESCRIPTION
If removeData isn't awaited, the logoutBox method might complete before the data is actually deleted from the Hive box, which could lead to bugs or inconsistent states in application
