### PR TITLE
chore: simplify theme code

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
   - Firebase/Crashlytics (12.15.0):
     - Firebase/CoreOnly
     - FirebaseCrashlytics (~> 12.15.0)
-  - firebase_analytics (12.4.3):
+  - firebase_analytics (12.4.5):
     - firebase_core
     - FirebaseAnalytics (= 12.15.0)
     - Flutter
-  - firebase_core (4.11.0):
+  - firebase_core (4.12.1):
     - Firebase/CoreOnly (= 12.15.0)
     - Flutter
-  - firebase_crashlytics (5.2.4):
+  - firebase_crashlytics (5.2.6):
     - Firebase/Crashlytics (= 12.15.0)
     - firebase_core
     - Flutter
@@ -175,9 +175,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Firebase: a8539b633d474fbeb654c7043f9c1649e274045b
-  firebase_analytics: 5e356f558625ce2d8b21deff00946b56d6e8d0d5
-  firebase_core: fc23178af8ea070194d09031ae4198a9608a3d22
-  firebase_crashlytics: 344bb168f55aee1086c6cdd0b105a9db018cd344
+  firebase_analytics: eb8345c126a25cd1914597079faf3e64c2e6835f
+  firebase_core: 1c1e250a77e2df9e80bb8bf0875c8b427044a697
+  firebase_crashlytics: 4d38aa785af57b2687a460778303d3b459707192
   FirebaseAnalytics: 9c9fa7915fc52ea03077000d5a7b6a8947b2d76e
   FirebaseCore: 2e86a4ea1684d4381707069e4a6d89ac808e901e
   FirebaseCoreExtension: 10d2a627977b39418759ad88ada80fbbd34f1c4f
@@ -198,4 +198,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 0dbd5a87e0ace00c9610d2037ac22083a01f861d
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/lib/core/resources/styles.dart
+++ b/lib/core/resources/styles.dart
@@ -36,63 +36,63 @@ ThemeData themeLight(BuildContext context) => ThemeData(
     shadow: Palette.shadow,
   ),
   textTheme: TextTheme(
-    displayLarge: Theme.of(context).textTheme.displayLarge?.copyWith(
+    displayLarge: TextTheme.of(context).displayLarge?.copyWith(
       fontSize: Dimens.displayLarge,
       color: Palette.textPrimary,
     ),
-    displayMedium: Theme.of(context).textTheme.displayMedium?.copyWith(
+    displayMedium: TextTheme.of(context).displayMedium?.copyWith(
       fontSize: Dimens.displayMedium,
       color: Palette.textPrimary,
     ),
-    displaySmall: Theme.of(context).textTheme.displaySmall?.copyWith(
+    displaySmall: TextTheme.of(context).displaySmall?.copyWith(
       fontSize: Dimens.displaySmall,
       color: Palette.textPrimary,
     ),
-    headlineLarge: Theme.of(context).textTheme.headlineLarge?.copyWith(
+    headlineLarge: TextTheme.of(context).headlineLarge?.copyWith(
       fontSize: Dimens.headlineLarge,
       color: Palette.textPrimary,
     ),
-    headlineMedium: Theme.of(context).textTheme.headlineMedium?.copyWith(
+    headlineMedium: TextTheme.of(context).headlineMedium?.copyWith(
       fontSize: Dimens.headlineMedium,
       color: Palette.textPrimary,
     ),
-    headlineSmall: Theme.of(context).textTheme.headlineSmall?.copyWith(
+    headlineSmall: TextTheme.of(context).headlineSmall?.copyWith(
       fontSize: Dimens.headlineSmall,
       color: Palette.textPrimary,
     ),
-    titleLarge: Theme.of(context).textTheme.titleLarge?.copyWith(
+    titleLarge: TextTheme.of(context).titleLarge?.copyWith(
       fontSize: Dimens.titleLarge,
       color: Palette.textPrimary,
     ),
-    titleMedium: Theme.of(context).textTheme.titleMedium?.copyWith(
+    titleMedium: TextTheme.of(context).titleMedium?.copyWith(
       fontSize: Dimens.titleMedium,
       color: Palette.textPrimary,
     ),
-    titleSmall: Theme.of(context).textTheme.titleSmall?.copyWith(
+    titleSmall: TextTheme.of(context).titleSmall?.copyWith(
       fontSize: Dimens.titleSmall,
       color: Palette.textPrimary,
     ),
-    bodyLarge: Theme.of(context).textTheme.bodyLarge?.copyWith(
+    bodyLarge: TextTheme.of(context).bodyLarge?.copyWith(
       fontSize: Dimens.bodyLarge,
       color: Palette.textPrimary,
     ),
-    bodyMedium: Theme.of(context).textTheme.bodyMedium?.copyWith(
+    bodyMedium: TextTheme.of(context).bodyMedium?.copyWith(
       fontSize: Dimens.bodyMedium,
       color: Palette.textPrimary,
     ),
-    bodySmall: Theme.of(context).textTheme.bodySmall?.copyWith(
+    bodySmall: TextTheme.of(context).bodySmall?.copyWith(
       fontSize: Dimens.bodySmall,
       color: Palette.textPrimary,
     ),
-    labelLarge: Theme.of(context).textTheme.labelLarge?.copyWith(
+    labelLarge: TextTheme.of(context).labelLarge?.copyWith(
       fontSize: Dimens.labelLarge,
       color: Palette.textPrimary,
     ),
-    labelMedium: Theme.of(context).textTheme.labelMedium?.copyWith(
+    labelMedium: TextTheme.of(context).labelMedium?.copyWith(
       fontSize: Dimens.labelMedium,
       color: Palette.textPrimary,
     ),
-    labelSmall: Theme.of(context).textTheme.labelSmall?.copyWith(
+    labelSmall: TextTheme.of(context).labelSmall?.copyWith(
       fontSize: Dimens.labelSmall,
       letterSpacing: 0.25,
       color: Palette.textPrimary,
@@ -184,63 +184,63 @@ ThemeData themeDark(BuildContext context) => ThemeData(
     shadow: Palette.shadowDark,
   ),
   textTheme: TextTheme(
-    displayLarge: Theme.of(context).textTheme.displayLarge?.copyWith(
+    displayLarge: TextTheme.of(context).displayLarge?.copyWith(
       fontSize: Dimens.displayLarge,
       color: Palette.textPrimaryDark,
     ),
-    displayMedium: Theme.of(context).textTheme.displayMedium?.copyWith(
+    displayMedium: TextTheme.of(context).displayMedium?.copyWith(
       fontSize: Dimens.displayMedium,
       color: Palette.textPrimaryDark,
     ),
-    displaySmall: Theme.of(context).textTheme.displaySmall?.copyWith(
+    displaySmall: TextTheme.of(context).displaySmall?.copyWith(
       fontSize: Dimens.displaySmall,
       color: Palette.textPrimaryDark,
     ),
-    headlineLarge: Theme.of(context).textTheme.headlineLarge?.copyWith(
+    headlineLarge: TextTheme.of(context).headlineLarge?.copyWith(
       fontSize: Dimens.headlineLarge,
       color: Palette.textPrimaryDark,
     ),
-    headlineMedium: Theme.of(context).textTheme.headlineMedium?.copyWith(
+    headlineMedium: TextTheme.of(context).headlineMedium?.copyWith(
       fontSize: Dimens.headlineMedium,
       color: Palette.textPrimaryDark,
     ),
-    headlineSmall: Theme.of(context).textTheme.headlineSmall?.copyWith(
+    headlineSmall: TextTheme.of(context).headlineSmall?.copyWith(
       fontSize: Dimens.headlineSmall,
       color: Palette.textPrimaryDark,
     ),
-    titleLarge: Theme.of(context).textTheme.titleLarge?.copyWith(
+    titleLarge: TextTheme.of(context).titleLarge?.copyWith(
       fontSize: Dimens.titleLarge,
       color: Palette.textPrimaryDark,
     ),
-    titleMedium: Theme.of(context).textTheme.titleMedium?.copyWith(
+    titleMedium: TextTheme.of(context).titleMedium?.copyWith(
       fontSize: Dimens.titleMedium,
       color: Palette.textPrimaryDark,
     ),
-    titleSmall: Theme.of(context).textTheme.titleSmall?.copyWith(
+    titleSmall: TextTheme.of(context).titleSmall?.copyWith(
       fontSize: Dimens.titleSmall,
       color: Palette.textPrimaryDark,
     ),
-    bodyLarge: Theme.of(context).textTheme.bodyLarge?.copyWith(
+    bodyLarge: TextTheme.of(context).bodyLarge?.copyWith(
       fontSize: Dimens.bodyLarge,
       color: Palette.textPrimaryDark,
     ),
-    bodyMedium: Theme.of(context).textTheme.bodyMedium?.copyWith(
+    bodyMedium: TextTheme.of(context).bodyMedium?.copyWith(
       fontSize: Dimens.bodyMedium,
       color: Palette.textPrimaryDark,
     ),
-    bodySmall: Theme.of(context).textTheme.bodySmall?.copyWith(
+    bodySmall: TextTheme.of(context).bodySmall?.copyWith(
       fontSize: Dimens.bodySmall,
       color: Palette.textPrimaryDark,
     ),
-    labelLarge: Theme.of(context).textTheme.labelLarge?.copyWith(
+    labelLarge: TextTheme.of(context).labelLarge?.copyWith(
       fontSize: Dimens.labelLarge,
       color: Palette.textPrimaryDark,
     ),
-    labelMedium: Theme.of(context).textTheme.labelMedium?.copyWith(
+    labelMedium: TextTheme.of(context).labelMedium?.copyWith(
       fontSize: Dimens.labelMedium,
       color: Palette.textPrimaryDark,
     ),
-    labelSmall: Theme.of(context).textTheme.labelSmall?.copyWith(
+    labelSmall: TextTheme.of(context).labelSmall?.copyWith(
       fontSize: Dimens.labelSmall,
       letterSpacing: 0.25,
       color: Palette.textPrimaryDark,
@@ -408,7 +408,7 @@ class BoxDecorations {
   final BuildContext context;
 
   BoxDecoration get button => BoxDecoration(
-    color: Theme.of(context).colorScheme.primary,
+    color: ColorScheme.of(context).primary,
     borderRadius: BorderRadius.all(Radius.circular(Dimens.cornerRadius)),
     boxShadow: [BoxShadows(context).button],
   );
@@ -437,36 +437,36 @@ class BoxShadows {
   final BuildContext context;
 
   BoxShadow get button => BoxShadow(
-    color: Theme.of(context).colorScheme.shadow.withAlpha(10),
+    color: ColorScheme.of(context).shadow.withAlpha(10),
     blurRadius: 16.0,
     spreadRadius: 1.0,
   );
 
   BoxShadow get card => BoxShadow(
-    color: Theme.of(context).colorScheme.shadow.withAlpha(10),
+    color: ColorScheme.of(context).shadow.withAlpha(10),
     blurRadius: 5.0,
     spreadRadius: 0.5,
   );
 
   BoxShadow get dialog => BoxShadow(
-    color: Theme.of(context).colorScheme.shadow.withAlpha(30),
+    color: ColorScheme.of(context).shadow.withAlpha(30),
     offset: const Offset(0, -4),
     blurRadius: 16.0,
   );
 
   BoxShadow get dialogAlt => BoxShadow(
-    color: Theme.of(context).colorScheme.shadow.withAlpha(30),
+    color: ColorScheme.of(context).shadow.withAlpha(30),
     offset: const Offset(0, 4),
     blurRadius: 16.0,
   );
 
   BoxShadow get buttonMenu => BoxShadow(
-    color: Theme.of(context).colorScheme.shadow.withAlpha(10),
+    color: ColorScheme.of(context).shadow.withAlpha(10),
     blurRadius: 4.0,
   );
 
   BoxShadow get navigation => BoxShadow(
-    color: Theme.of(context).colorScheme.shadow.withAlpha(30),
+    color: ColorScheme.of(context).shadow.withAlpha(30),
     blurRadius: Dimens.space6,
     offset: Offset(0, Dimens.space6),
   );

--- a/lib/core/widgets/button.dart
+++ b/lib/core/widgets/button.dart
@@ -30,9 +30,9 @@ class Button extends StatelessWidget {
       style: TextButton.styleFrom(
         backgroundColor: color ?? ColorScheme.of(context).primary,
         foregroundColor: titleColor ?? ColorScheme.of(context).onPrimary,
-        disabledBackgroundColor: Theme.of(
+        disabledBackgroundColor: ColorScheme.of(
           context,
-        ).colorScheme.primary.withValues(alpha: 0.5),
+        ).primary.withValues(alpha: 0.5),
         padding: EdgeInsets.symmetric(
           horizontal: Dimens.space24,
           vertical: Dimens.space12,

--- a/lib/core/widgets/button.dart
+++ b/lib/core/widgets/button.dart
@@ -28,8 +28,8 @@ class Button extends StatelessWidget {
     child: TextButton(
       onPressed: onPressed,
       style: TextButton.styleFrom(
-        backgroundColor: color ?? Theme.of(context).colorScheme.primary,
-        foregroundColor: titleColor ?? Theme.of(context).colorScheme.onPrimary,
+        backgroundColor: color ?? ColorScheme.of(context).primary,
+        foregroundColor: titleColor ?? ColorScheme.of(context).onPrimary,
         disabledBackgroundColor: Theme.of(
           context,
         ).colorScheme.primary.withValues(alpha: 0.5),
@@ -43,8 +43,8 @@ class Button extends StatelessWidget {
       ),
       child: Text(
         title,
-        style: Theme.of(context).textTheme.bodyMedium500?.copyWith(
-          color: titleColor ?? Theme.of(context).colorScheme.onPrimary,
+        style: TextTheme.of(context).bodyMedium500?.copyWith(
+          color: titleColor ?? ColorScheme.of(context).onPrimary,
           fontSize: fontSize,
         ),
         textAlign: TextAlign.center,

--- a/lib/core/widgets/button_notification.dart
+++ b/lib/core/widgets/button_notification.dart
@@ -6,44 +6,44 @@ class ButtonNotification extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => IconButton(
-      icon: SizedBox(
-        width: Dimens.space36,
-        height: Dimens.space36,
-        child: Stack(
-          children: [
-            Positioned(
-              left: 0,
-              top: 0,
-              bottom: 0,
-              child: Icon(Icons.notifications_outlined, size: Dimens.space30),
-            ),
-            Positioned(
-              right: Dimens.space4,
-              bottom: Dimens.space6,
-              child: Visibility(
-                child: CircleAvatar(
-                  backgroundColor: Palette.secondary,
-                  maxRadius: Dimens.space8,
-                  child: Center(
-                    child: Text(
-                      '1',
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: Theme.of(
-                          context,
-                        ).extension<LzyctColors>()!.background,
-                      ),
-                      textAlign: TextAlign.center,
+    icon: SizedBox(
+      width: Dimens.space36,
+      height: Dimens.space36,
+      child: Stack(
+        children: [
+          Positioned(
+            left: 0,
+            top: 0,
+            bottom: 0,
+            child: Icon(Icons.notifications_outlined, size: Dimens.space30),
+          ),
+          Positioned(
+            right: Dimens.space4,
+            bottom: Dimens.space6,
+            child: Visibility(
+              child: CircleAvatar(
+                backgroundColor: Palette.secondary,
+                maxRadius: Dimens.space8,
+                child: Center(
+                  child: Text(
+                    '1',
+                    style: TextTheme.of(context).labelSmall?.copyWith(
+                      color: Theme.of(
+                        context,
+                      ).extension<LzyctColors>()!.background,
                     ),
+                    textAlign: TextAlign.center,
                   ),
                 ),
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
-      onPressed: () {
-        ///TODO: Go to notifications page
-        // context.goTo(AppRoute.notifications);
-      },
-    );
+    ),
+    onPressed: () {
+      ///TODO: Go to notifications page
+      // context.goTo(AppRoute.notifications);
+    },
+  );
 }

--- a/lib/core/widgets/button_text.dart
+++ b/lib/core/widgets/button_text.dart
@@ -28,11 +28,11 @@ class ButtonText extends StatelessWidget {
     child: TextButton(
       onPressed: onPressed,
       style: TextButton.styleFrom(
-        foregroundColor: titleColor ?? Theme.of(context).colorScheme.tertiary,
+        foregroundColor: titleColor ?? ColorScheme.of(context).tertiary,
       ),
       child: Text(
         title.toUpperCase(),
-        style: Theme.of(context).textTheme.bodyMedium500,
+        style: TextTheme.of(context).bodyMedium500,
         textAlign: TextAlign.center,
       ),
     ),

--- a/lib/core/widgets/drop_down.dart
+++ b/lib/core/widgets/drop_down.dart
@@ -45,7 +45,7 @@ class _DropDownState<T> extends State<DropDown<T>> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (widget.hintIsVisible && widget.hint != null) ...{
-          Text(widget.hint ?? '', style: Theme.of(context).textTheme.bodySmall),
+          Text(widget.hint ?? '', style: TextTheme.of(context).bodySmall),
           SpacerV(value: Dimens.space6),
         },
         ButtonTheme(
@@ -58,22 +58,19 @@ class _DropDownState<T> extends State<DropDown<T>> {
             focusNode: _fnDropdown,
             dropdownColor: Theme.of(context).scaffoldBackgroundColor,
             icon: _fnDropdown.hasFocus
-                ? Icon(
-                    Icons.check,
-                    color: Theme.of(context).colorScheme.primary,
-                  )
+                ? Icon(Icons.check, color: ColorScheme.of(context).primary)
                 : const Icon(Icons.keyboard_arrow_down),
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context).hintColor,
-            ),
+            style: TextTheme.of(
+              context,
+            ).bodyMedium?.copyWith(color: Theme.of(context).hintColor),
             decoration: InputDecoration(
               alignLabelWithHint: true,
               isDense: true,
               isCollapsed: true,
               filled: true,
-              labelStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: Theme.of(context).hintColor,
-              ),
+              labelStyle: TextTheme.of(
+                context,
+              ).bodyMedium?.copyWith(color: Theme.of(context).hintColor),
               fillColor: Theme.of(context).cardColor,
               prefixIcon: Padding(
                 padding: EdgeInsets.only(left: Dimens.space12),
@@ -103,7 +100,7 @@ class _DropDownState<T> extends State<DropDown<T>> {
                 gapPadding: 0,
                 borderRadius: BorderRadius.circular(Dimens.space16),
                 borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.error,
+                  color: ColorScheme.of(context).error,
                   width: Dimens.space2,
                 ),
               ),
@@ -111,7 +108,7 @@ class _DropDownState<T> extends State<DropDown<T>> {
                 gapPadding: 0,
                 borderRadius: BorderRadius.circular(Dimens.space16),
                 borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.error,
+                  color: ColorScheme.of(context).error,
                   width: Dimens.space2,
                 ),
               ),
@@ -119,7 +116,7 @@ class _DropDownState<T> extends State<DropDown<T>> {
                 gapPadding: 0,
                 borderRadius: BorderRadius.circular(Dimens.space16),
                 borderSide: BorderSide(
-                  color: Theme.of(context).colorScheme.primary,
+                  color: ColorScheme.of(context).primary,
                   width: Dimens.space2,
                 ),
               ),

--- a/lib/core/widgets/text_f.dart
+++ b/lib/core/widgets/text_f.dart
@@ -81,14 +81,11 @@ class TextFState extends State<TextF> {
       children: [
         Text(
           widget.label,
-          style: widget.labelTextStyle ?? Theme.of(context).textTheme.bodySmall,
+          style: widget.labelTextStyle ?? TextTheme.of(context).bodySmall,
         ),
         _textFormField,
         if (widget.description != null)
-          Text(
-            widget.description!,
-            style: Theme.of(context).textTheme.bodySmall,
-          ),
+          Text(widget.description!, style: TextTheme.of(context).bodySmall),
         SpacerV(value: Dimens.space4),
       ],
     ),
@@ -110,7 +107,7 @@ class TextFState extends State<TextF> {
       maxLines: widget.maxLines,
       onTap: widget.onTap,
       textAlignVertical: TextAlignVertical.center,
-      style: widget.textStyle ?? Theme.of(context).textTheme.bodyMedium500,
+      style: widget.textStyle ?? TextTheme.of(context).bodyMedium500,
       decoration: InputDecoration(
         isDense: true,
         filled: true,
@@ -121,23 +118,23 @@ class TextFState extends State<TextF> {
         ),
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(Dimens.space16),
-          borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
+          borderSide: BorderSide(color: ColorScheme.of(context).outline),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(Dimens.space16),
           borderSide: BorderSide(
-            color: Theme.of(context).colorScheme.primary,
+            color: ColorScheme.of(context).primary,
             width: Dimens.space2,
           ),
         ),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(Dimens.space16),
-          borderSide: BorderSide(color: Theme.of(context).colorScheme.outline),
+          borderSide: BorderSide(color: ColorScheme.of(context).outline),
         ),
         errorBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(Dimens.space16),
           borderSide: BorderSide(
-            color: Theme.of(context).colorScheme.error,
+            color: ColorScheme.of(context).error,
             width: Dimens.space2,
           ),
         ),

--- a/lib/core/widgets/text_f.dart
+++ b/lib/core/widgets/text_f.dart
@@ -157,9 +157,9 @@ class TextFState extends State<TextF> {
         floatingLabelBehavior: widget.hint != null
             ? FloatingLabelBehavior.always
             : null,
-        hintStyle: Theme.of(
+        hintStyle: TextTheme.of(
           context,
-        ).textTheme.bodyMedium?.copyWith(color: Theme.of(context).hintColor),
+        ).bodyMedium?.copyWith(color: Theme.of(context).hintColor),
       ),
       validator: widget.validator,
       onChanged: (String value) =>

--- a/lib/features/auth/pages/login/login_page.dart
+++ b/lib/features/auth/pages/login/login_page.dart
@@ -103,7 +103,7 @@ class _LoginPageState extends State<LoginPage> {
           textInputType: TextInputType.emailAddress,
           prefixIcon: Icon(
             Icons.alternate_email,
-            color: Theme.of(context).textTheme.bodyLarge?.color,
+            color: TextTheme.of(context).bodyLarge?.color,
           ),
           hint: 'mudassir@lazycatlabs.com',
           label: Strings.of(context)!.email,
@@ -122,7 +122,7 @@ class _LoginPageState extends State<LoginPage> {
             textInputType: TextInputType.text,
             prefixIcon: Icon(
               Icons.lock_outline,
-              color: Theme.of(context).textTheme.bodyLarge?.color,
+              color: TextTheme.of(context).bodyLarge?.color,
             ),
             obscureText: !isPasswordVisible,
             hint: 'pass123',

--- a/lib/features/auth/pages/register/register_page.dart
+++ b/lib/features/auth/pages/register/register_page.dart
@@ -109,7 +109,7 @@ class _RegisterPageState extends State<RegisterPage> {
           textInputType: TextInputType.text,
           prefixIcon: Icon(
             Icons.person,
-            color: Theme.of(context).textTheme.bodyLarge?.color,
+            color: TextTheme.of(context).bodyLarge?.color,
           ),
           hint: 'Mudassir',
           label: Strings.of(context)!.name,
@@ -125,7 +125,7 @@ class _RegisterPageState extends State<RegisterPage> {
           textInputType: TextInputType.emailAddress,
           prefixIcon: Icon(
             Icons.alternate_email,
-            color: Theme.of(context).textTheme.bodyLarge?.color,
+            color: TextTheme.of(context).bodyLarge?.color,
           ),
           hint: 'mudassir@lazycatlabs.com',
           label: Strings.of(context)!.email,
@@ -143,7 +143,7 @@ class _RegisterPageState extends State<RegisterPage> {
             textInputType: TextInputType.text,
             prefixIcon: Icon(
               Icons.lock_outline,
-              color: Theme.of(context).textTheme.bodyLarge?.color,
+              color: TextTheme.of(context).bodyLarge?.color,
             ),
             obscureText: !isPasswordVisible,
             hint: '••••••••••••',
@@ -172,7 +172,7 @@ class _RegisterPageState extends State<RegisterPage> {
             textInputType: TextInputType.text,
             prefixIcon: Icon(
               Icons.lock_outline,
-              color: Theme.of(context).textTheme.bodyLarge?.color,
+              color: TextTheme.of(context).bodyLarge?.color,
             ),
             obscureText: !isPasswordRepeatVisible,
             hint: '••••••••••••',

--- a/lib/features/general/pages/main/main_page.dart
+++ b/lib/features/general/pages/main/main_page.dart
@@ -58,20 +58,20 @@ class _MainPageState extends State<MainPage> {
               builder: (_) => AlertDialog(
                 title: Text(
                   Strings.of(context)!.logout,
-                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
+                  style: TextTheme.of(
+                    context,
+                  ).bodyLarge?.copyWith(color: ColorScheme.of(context).error),
                 ),
                 content: Text(
                   Strings.of(context)!.logoutDesc,
-                  style: Theme.of(context).textTheme.bodyMedium,
+                  style: TextTheme.of(context).bodyMedium,
                 ),
                 actions: [
                   TextButton(
                     onPressed: () => context.pop(),
                     child: Text(
                       Strings.of(context)!.cancel,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      style: TextTheme.of(context).bodyMedium?.copyWith(
                         color: Theme.of(context).hintColor,
                       ),
                     ),
@@ -96,8 +96,8 @@ class _MainPageState extends State<MainPage> {
                       },
                       child: Text(
                         Strings.of(context)!.yes,
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.error,
+                        style: TextTheme.of(context).bodyMedium?.copyWith(
+                          color: ColorScheme.of(context).error,
                         ),
                       ),
                     ),
@@ -122,7 +122,7 @@ class _MainPageState extends State<MainPage> {
         builder: (_, state) => Text(switch (state) {
           MainStateLoading() => '-',
           MainStateSuccess(:final data) => data?.title ?? '-',
-        }, style: Theme.of(context).textTheme.titleLarge),
+        }, style: TextTheme.of(context).titleLarge),
       ),
       leading: IconButton(
         icon: Icon(Icons.sort, size: Dimens.space24, semanticLabel: 'Menu'),

--- a/lib/features/general/pages/main/menu_drawer.dart
+++ b/lib/features/general/pages/main/menu_drawer.dart
@@ -27,7 +27,7 @@ class MenuDrawer extends StatelessWidget {
           width: context.widthInPercent(100),
           height: Dimens.header,
           padding: EdgeInsets.symmetric(horizontal: Dimens.space16),
-          color: Theme.of(context).colorScheme.primary,
+          color: ColorScheme.of(context).primary,
           child: SafeArea(
             child: BlocBuilder<UserCubit, UserState>(
               builder: (_, state) => switch (state) {
@@ -39,7 +39,7 @@ class MenuDrawer extends StatelessWidget {
                 UserStateFailure(:final message) => Center(
                   child: Text(
                     message,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    style: TextTheme.of(context).bodyMedium?.copyWith(
                       color: Theme.of(
                         context,
                       ).extension<LzyctColors>()!.textOnPrimary,
@@ -61,7 +61,7 @@ class MenuDrawer extends StatelessWidget {
                         children: [
                           Text(
                             "${data?.name ?? ""} ${data?.isVerified ?? false ? "✅" : ""}",
-                            style: Theme.of(context).textTheme.titleLargeBold
+                            style: TextTheme.of(context).titleLargeBold
                                 ?.copyWith(
                                   color: Theme.of(
                                     context,
@@ -70,12 +70,11 @@ class MenuDrawer extends StatelessWidget {
                           ),
                           Text(
                             data?.email ?? '',
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(
-                                  color: Theme.of(
-                                    context,
-                                  ).extension<LzyctColors>()!.textOnPrimary,
-                                ),
+                            style: TextTheme.of(context).bodySmall?.copyWith(
+                              color: Theme.of(
+                                context,
+                              ).extension<LzyctColors>()!.textOnPrimary,
+                            ),
                           ),
                         ],
                       ),
@@ -115,7 +114,7 @@ class MenuDrawer extends StatelessWidget {
                           ),
                           child: Text(
                             value.title!,
-                            style: Theme.of(context).textTheme.bodyLarge,
+                            style: TextTheme.of(context).bodyLarge,
                           ),
                         ),
                       ),

--- a/lib/features/general/pages/settings/settings_page.dart
+++ b/lib/features/general/pages/settings/settings_page.dart
@@ -47,7 +47,7 @@ class _SettingsPageState extends State<SettingsPage> with MainBoxMixin {
                       value: data,
                       child: Text(
                         _getThemeName(data, context),
-                        style: Theme.of(context).textTheme.bodyMedium,
+                        style: TextTheme.of(context).bodyMedium,
                       ),
                     ),
                   )
@@ -77,7 +77,7 @@ class _SettingsPageState extends State<SettingsPage> with MainBoxMixin {
                       value: data,
                       child: Text(
                         data.title ?? '-',
-                        style: Theme.of(context).textTheme.bodyMedium,
+                        style: TextTheme.of(context).bodyMedium,
                       ),
                     ),
                   )

--- a/lib/features/users/pages/dashboard/dashboard_page.dart
+++ b/lib/features/users/pages/dashboard/dashboard_page.dart
@@ -27,7 +27,7 @@ class _DashboardPageState extends State<DashboardPage> {
   @override
   Widget build(BuildContext context) => Parent(
     child: RefreshIndicator(
-      color: Theme.of(context).colorScheme.primary,
+      color: ColorScheme.of(context).primary,
       backgroundColor: Theme.of(context).extension<LzyctColors>()!.background,
       onRefresh: () => context.read<UsersCubit>().refresh(),
       child: BlocBuilder<UsersCubit, UsersState>(
@@ -86,27 +86,27 @@ class _DashboardPageState extends State<DashboardPage> {
               children: [
                 Text(
                   user.name ?? '',
-                  style: Theme.of(context).textTheme.titleLargeBold,
+                  style: TextTheme.of(context).titleLargeBold,
                 ),
                 Text(
                   user.email ?? '',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).hintColor,
-                  ),
+                  style: TextTheme.of(
+                    context,
+                  ).bodySmall?.copyWith(color: Theme.of(context).hintColor),
                 ),
                 const SpacerV(),
                 Row(
                   children: [
                     Text(
                       Strings.of(context)!.lastUpdate,
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      style: TextTheme.of(context).labelSmall?.copyWith(
                         color: Theme.of(context).hintColor,
                       ),
                     ),
                     Flexible(
                       child: Text(
                         (user.updatedAt ?? '').toStringDateAlt(),
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        style: TextTheme.of(context).labelSmall?.copyWith(
                           color: Theme.of(context).hintColor,
                         ),
                         textAlign: TextAlign.end,

--- a/lib/utils/ext/string.dart
+++ b/lib/utils/ext/string.dart
@@ -20,7 +20,7 @@ extension StringExtension on String {
 
       showToastWidget(
         Toast(
-          bgColor: Theme.of(context).colorScheme.error,
+          bgColor: ColorScheme.of(context).error,
           icon: Icons.error,
           message: message,
           textColor: Colors.white,
@@ -47,7 +47,7 @@ extension StringExtension on String {
       // showToast(msg)
       showToastWidget(
         Toast(
-          bgColor: Theme.of(context).colorScheme.primary,
+          bgColor: ColorScheme.of(context).primary,
           icon: Icons.check_circle,
           message: message,
           textColor: Colors.white,
@@ -72,7 +72,7 @@ extension StringExtension on String {
 
       showToastWidget(
         Toast(
-          bgColor: Theme.of(context).colorScheme.tertiary,
+          bgColor: ColorScheme.of(context).tertiary,
           icon: Icons.info,
           message: message,
           textColor: Colors.white,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,9 +62,9 @@ dependencies:
   logger: ^2.7.0
 
   # Firebase
-  firebase_core: ^4.11.0
-  firebase_analytics: ^12.4.3
-  firebase_crashlytics: ^5.2.4
+  firebase_core: ^4.12.1
+  firebase_analytics: ^12.4.5
+  firebase_crashlytics: ^5.2.6
 
   # router
   go_router: ^17.3.0
@@ -84,7 +84,7 @@ dev_dependencies:
   lint: ^2.8.0
   flutter_lints: ^6.0.0
   bloc_test: ^10.0.0
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   http_mock_adapter: ^0.6.1
 
   # Pinned until Freezed supports Analyzer 13.


### PR DESCRIPTION
## What it does

- Simplifies theme lookups by replacing repeated `Theme.of(context).colorScheme` and `Theme.of(context).textTheme` calls with `ColorScheme.of(context)` and `TextTheme.of(context)`.
- Applies the simplified theme access pattern across shared widgets and the login, register, drawer, settings, main, and dashboard screens.
- Keeps the existing visual theme behavior while reducing verbose theme access code.
- Updates Firebase package versions and `build_runner`, with the matching iOS `Podfile.lock` changes.

## How to test

1. Launch the app and confirm the login screen still shows the updated colors, typography, icons, input fields, and primary button styling.
2. Tap through the login email and password fields, toggle password visibility, and confirm focus, text color, and validation styling still behave normally.
3. Open the register screen, move through name, email, password, and repeat password fields, and confirm validation messages and password visibility controls still appear correctly.
4. Sign in or navigate into the app, then review the main screen, drawer, dashboard, and settings pages to confirm themed cards, buttons, labels, icons, and shadows still render consistently.
5. Switch between light and dark appearance if available and confirm the same screens continue to use the expected theme colors.

## Screenshot

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual consistency by standardizing typography and color sources across light and dark themes.
  * Updated buttons, dropdowns, text inputs, menus, dialogs, notifications, toasts, and refresh indicators to use the unified theme styling.
  * Refreshed icon and label text coloring in login/registration and main/user screens to match the new theme behavior.
* **Chores**
  * Bumped Firebase and build tooling dependency versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->